### PR TITLE
Use exec() function in both Python 2 and Python 3

### DIFF
--- a/bistro/cmake/targets_to_cmake_lists.py
+++ b/bistro/cmake/targets_to_cmake_lists.py
@@ -153,7 +153,7 @@ def parse_targets(dirpath, s):
         )
 
     fn_locals = locals()
-    exec s in {l: fn_locals[l] for l in (
+    fn_locals = {symbol: fn_locals[symbol] for symbol in (
         'cpp_benchmark',
         'cpp_binary',
         'cpp_library',
@@ -163,6 +163,7 @@ def parse_targets(dirpath, s):
         'glob',
         'load',
     )}
+    exec(s, fn_locals)
 
     return cmake_lines
 


### PR DESCRIPTION
Legacy __exec__ statements are syntax errors in Python 3 but __exec()__ function works as expected in both Python 2 and Python 3.  

This PR attempts to solve a corner case described in https://github.com/facebook/bistro/pull/34#issuecomment-513992204 where having a dict comprehension inside an __exec()__ function call can be problematic.

@snarkmaster 