### PR TITLE
The sudo: tag is now fully deprecated in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 # Facebook projects that use `fbcode_builder` for continuous integration
 # share this Travis configuration to run builds via Docker.
 
-sudo: required
-
 # Docker disables IPv6 in containers by default. Enable it for unit tests that need [::1].
 before_script:
   - if [[ "$TRAVIS_OS_NAME" != "osx" ]];


### PR DESCRIPTION
__sudo: required__ no longer is.  Travis CI has fully deprecated the __sudo:__ tag because the sudo command is now _always_ available and there is no way to turn it off.