### PR TITLE
docs: adding ELI5 video to the home page 

### DIFF
--- a/index.md
+++ b/index.md
@@ -5,6 +5,15 @@ id: home
 hero: true
 ---
 
+<div align="center">
+  <h3>Watch Introductory Video</h3>
+  <iframe width="560" height="315" src="https://www.youtube.com/embed/IXlZYBft_rY" 
+    title="Explain Like I'm 5: Bistro" frameBorder="0" 
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" 
+    allowFullScreen ></iframe>
+</div>
+<br/>
+
 {% include content/gridblocks.html data_source=site.data.features grid_type="threeByGridBlockLeft" %}
 
 ## Why Use Bistro?


### PR DESCRIPTION
## Summary
Here at Meta Open Source, we've been creating short-form videos to explain Meta OSS projects in the simplest terms possible called ELI5s. We have also been working on React Labs series that we would like to add to the site. We started embedding these videos into project pages as you can see in [Docusaurus home page](https://docusaurus.io/), [Recoil](https://recoiljs.org/), [Litho](https://fblitho.com/), [Jest](https://jestjs.io/), [React Native](https://reactnative.dev/),[Hydra](https://hydra.cc/), and over 20 other projects.

## Test plan
![image](https://user-images.githubusercontent.com/12485205/155637948-bfadc7e2-6a1f-41ce-83d5-92a794cb1743.png)
